### PR TITLE
Fix double prefix in pkgconfig files

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,7 +15,7 @@ cmake -G "Unix Makefiles" \
       ${CMAKE_ARGS} \
       -DCMAKE_BUILD_TYPE="Release" \
       -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-      -DCMAKE_INSTALL_LIBDIR="${PREFIX}/lib" \
+      -DCMAKE_INSTALL_LIBDIR="lib" \
       -DCMAKE_POSITION_INDEPENDENT_CODE=1 \
       -DBUILD_STATIC=0 \
       -DBUILD_SHARED=1 \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,8 +14,6 @@ fi
 cmake -G "Unix Makefiles" \
       ${CMAKE_ARGS} \
       -DCMAKE_BUILD_TYPE="Release" \
-      -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-      -DCMAKE_INSTALL_LIBDIR="lib" \
       -DCMAKE_POSITION_INDEPENDENT_CODE=1 \
       -DBUILD_STATIC=0 \
       -DBUILD_SHARED=1 \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: be608cdf68deb02e0d3ee62e183942a0fe5d5d3185375b9b6566e2ae35a9bdbd
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('c-blosc2') }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Prior to this change when trying to cross compile:
```
$ cat ../_h_env/lib/pkgconfig/blosc2.pc 
prefix=/home/conda/feedstock_root/build_artifacts/debug_1680560464317/_h_env
exec_prefix=${prefix}
libdir=${exec_prefix}//home/conda/feedstock_root/build_artifacts/debug_1680560464317/_h_env/lib
```

This causes pkg-config to output incorrect path, and ultimately the application fails to link.
```
$ pkg-config --libs blosc2
-L/home/conda/feedstock_root/build_artifacts/debug_1680560464317/_h_env//home/conda/feedstock_root/build_artifacts/debug_1680560464317/_h_env/lib -lblosc2
```
