### PR TITLE
Add lz4-c as runtime dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f2adcd9615f138d1bb16dc27feadab1bb1eab01d77e5e2323d14ad4ca8c3ca21
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('c-blosc2') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - lz4-c
     - zstd
     - zlib-ng
+  run:
+    - lz4-c
 
 test:
   commands:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


We are hitting the current error when trying to `find_package(blosc2)` with cmake.
 
```
2024-03-14T21:40:24.3713579Z -- No LZ4 library found.  Using internal sources.
2024-03-14T21:40:24.3717552Z CMake Warning at cmake/DetectOptions.cmake:77 (find_package):
2024-03-14T21:40:24.3718437Z   Found package configuration file:
2024-03-14T21:40:24.3718832Z 
2024-03-14T21:40:24.3719087Z     C:/Miniconda/Library/cmake/Blosc2Config.cmake
2024-03-14T21:40:24.3719546Z 
2024-03-14T21:40:24.3719967Z   but it set Blosc2_FOUND to FALSE so package "Blosc2" is considered to be
2024-03-14T21:40:24.3720736Z   NOT FOUND.  Reason given by package:
2024-03-14T21:40:24.3721096Z 
2024-03-14T21:40:24.3721464Z   Blosc2 could not be found because dependency LZ4 could not be found.
2024-03-14T21:40:24.3722010Z 
2024-03-14T21:40:24.3722198Z Call Stack (most recent call first):
2024-03-14T21:40:24.3722718Z   CMakeLists.txt:194 (include)
2024-03-14T21:40:24.3723044Z 
2024-03-14T21:40:24.3723050Z 
```